### PR TITLE
Add ability to ignore attribute shortcuts

### DIFF
--- a/test/core/test_html_structure.rb
+++ b/test/core/test_html_structure.rb
@@ -106,6 +106,13 @@ h1#title This is my title
     assert_html '<div class="admin" id="user" role="admin">Daniel</div>', source, shortcut: {'#' => {attr: 'id'}, '.' => {attr: 'class'}, '@' => {attr: 'role'}, '@.' => {attr: ['class', 'role']}}
   end
 
+  def test_render_with_ignored_shortcut
+    source = %q{
+#user@admin Daniel
+}
+    assert_html '<div id="user">Daniel</div>', source, shortcut: {'#' => {attr: 'id'}, '@' => {attr: false}}
+  end
+
   def test_render_with_custom_shortcut_and_additional_attrs
     source = %q{
 ^items

--- a/test/literate/TESTS.md
+++ b/test/literate/TESTS.md
@@ -1237,6 +1237,26 @@ renders as
 </div>
 ~~~
 
+#### Ignored attribute shortcuts
+
+Sometimes you need to disable rendering an attribute with a shortcut but still allow it to present in the template.
+
+~~~ options
+:shortcut => {'@' => {attr: false}, '#' => {attr: 'id'}}
+~~~
+
+~~~ slim
+#test@ignored
+#test
+~~~
+
+renders to
+
+~~~ html
+<div id="test"></div>
+<div id="test"></div>
+~~~
+
 ## Text interpolation
 
 Use standard Ruby interpolation. The text will be html escaped by default.


### PR DESCRIPTION
In case if you need to disable an attribute rendering set via shorcut.
For instance you can disable rendering element ids on production which
are used for testing purposes in staging env.
